### PR TITLE
feat: build admin lock/unlock account flow

### DIFF
--- a/src/main/java/com/digitalsanctuary/spring/user/api/AdminApi.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/api/AdminApi.java
@@ -35,22 +35,40 @@ public class AdminApi {
      * @param lockAccountDto the DTO containing the email of the user to be locked
      * @return a ResponseEntity containing a JSONResponse stating that user account has been locked
      * */
-    @PostMapping("/toggleLockStatus")
+    @PostMapping("/lockAccount")
     @PreAuthorize("hasAuthority('ADMIN_PRIVILEGE')")
-    public ResponseEntity<JSONResponse> toggleLockStatus(@Valid @RequestBody LockAccountDto lockAccountDto) {
-        log.info("AdminApi.toggleLockStatus: called with email: {}", lockAccountDto.getEmail());
+    public ResponseEntity<JSONResponse> lockAccount(@Valid @RequestBody LockAccountDto lockAccountDto) {
+        log.info("AdminApi.lockAccount: called with email: {}", lockAccountDto.getEmail());
         try {
             validateDto(lockAccountDto);
-            userService.toggleLockStatus(lockAccountDto.getEmail());
+            userService.lockAccount(lockAccountDto.getEmail());
             return buildSuccessResponse("User account locked successfully", null);
-        } catch(UsernameNotFoundException e) {
-            log.warn("AdminApi.toggleLockStatus: user not found: {}", lockAccountDto.getEmail());
+        } catch (UsernameNotFoundException e) {
+            log.warn("AdminApi.lockAccount: user not found: {}", lockAccountDto.getEmail());
             return buildErrorResponse("User not found", 2, HttpStatus.NOT_FOUND);
         } catch (IllegalArgumentException e) {
-            log.warn("AdminApi.toggleLockStatus: invalid argument: {}", e.getMessage());
+            log.warn("AdminApi.lockAccount: invalid argument: {}", e.getMessage());
             return buildErrorResponse(e.getMessage(), 1, HttpStatus.BAD_REQUEST);
         }
     }
+
+    @PostMapping("/unlockAccount")
+    @PreAuthorize("hasAuthority('ADMIN_PRIVILEGE')")
+    public ResponseEntity<JSONResponse> unlockAccount(@Valid @RequestBody LockAccountDto lockAccountDto) {
+        log.info("AdminApi.unlockAccount: called with email: {}", lockAccountDto.getEmail());
+        try {
+            validateDto(lockAccountDto);
+            userService.unlockAccount(lockAccountDto.getEmail());
+            return buildSuccessResponse("User account unlocked successfully", null);
+        } catch (UsernameNotFoundException e) {
+            log.warn("AdminApi.unlockAccount: user not found: {}", lockAccountDto.getEmail());
+            return buildErrorResponse("User not found", 2, HttpStatus.NOT_FOUND);
+        } catch (IllegalArgumentException e) {
+            log.warn("AdminApi.unlockAccount: invalid argument: {}", e.getMessage());
+            return buildErrorResponse(e.getMessage(), 1, HttpStatus.BAD_REQUEST);
+        }
+    }
+
 
     private void validateDto(LockAccountDto dto) {
         if(dto.getEmail() == null || dto.getEmail().isEmpty()) {

--- a/src/main/java/com/digitalsanctuary/spring/user/api/AdminApi.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/api/AdminApi.java
@@ -1,0 +1,60 @@
+package com.digitalsanctuary.spring.user.api;
+
+import com.digitalsanctuary.spring.user.dto.LockAccountDto;
+import com.digitalsanctuary.spring.user.service.UserService;
+import com.digitalsanctuary.spring.user.util.JSONResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.digitalsanctuary.spring.user.util.ResponseUtil.buildErrorResponse;
+import static com.digitalsanctuary.spring.user.util.ResponseUtil.buildSuccessResponse;
+
+/**
+ * REST controller for managing admin-related operations. This class handles locking of user account.
+ */
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(path = "/admin", produces = "application/json")
+public class AdminApi {
+    private final UserService userService;
+
+    /**
+     * Toggle Lock status for a user account.
+     *
+     * @param lockAccountDto the DTO containing the email of the user to be locked
+     * @return a ResponseEntity containing a JSONResponse stating that user account has been locked
+     * */
+    @PostMapping("/toggleLockStatus")
+    @PreAuthorize("hasAuthority('ADMIN_PRIVILEGE')")
+    public ResponseEntity<JSONResponse> toggleLockStatus(@Valid @RequestBody LockAccountDto lockAccountDto) {
+        log.info("AdminApi.toggleLockStatus: called with email: {}", lockAccountDto.getEmail());
+        try {
+            validateDto(lockAccountDto);
+            userService.toggleLockStatus(lockAccountDto.getEmail());
+            return buildSuccessResponse("User account locked successfully", null);
+        } catch(UsernameNotFoundException e) {
+            log.warn("AdminApi.toggleLockStatus: user not found: {}", lockAccountDto.getEmail());
+            return buildErrorResponse("User not found", 2, HttpStatus.NOT_FOUND);
+        } catch (IllegalArgumentException e) {
+            log.warn("AdminApi.toggleLockStatus: invalid argument: {}", e.getMessage());
+            return buildErrorResponse(e.getMessage(), 1, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateDto(LockAccountDto dto) {
+        if(dto.getEmail() == null || dto.getEmail().isEmpty()) {
+            throw new IllegalArgumentException("Email is required");
+        }
+    }
+}

--- a/src/main/java/com/digitalsanctuary/spring/user/api/UserAPI.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/api/UserAPI.java
@@ -1,6 +1,8 @@
 package com.digitalsanctuary.spring.user.api;
 
 import java.util.Locale;
+
+import com.digitalsanctuary.spring.user.util.ResponseUtil;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
@@ -30,6 +32,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import static com.digitalsanctuary.spring.user.util.ResponseUtil.buildErrorResponse;
+import static com.digitalsanctuary.spring.user.util.ResponseUtil.buildSuccessResponse;
 
 /**
  * REST controller for managing user-related operations. This class handles user registration, account deletion, and other user-related endpoints.
@@ -292,28 +297,5 @@ public class UserAPI {
 	 */
 	private boolean isNullOrEmpty(String value) {
 		return value == null || value.isEmpty();
-	}
-
-	/**
-	 * Builds an error response.
-	 *
-	 * @param message
-	 * @param code
-	 * @param status
-	 * @return a ResponseEntity containing a JSONResponse with the error response
-	 */
-	private ResponseEntity<JSONResponse> buildErrorResponse(String message, int code, HttpStatus status) {
-		return ResponseEntity.status(status).body(JSONResponse.builder().success(false).code(code).message(message).build());
-	}
-
-	/**
-	 * Builds a success response.
-	 *
-	 * @param message
-	 * @param redirectUrl
-	 * @return a ResponseEntity containing a JSONResponse with the success response
-	 */
-	private ResponseEntity<JSONResponse> buildSuccessResponse(String message, String redirectUrl) {
-		return ResponseEntity.ok(JSONResponse.builder().success(true).code(0).message(message).redirectUrl(redirectUrl).build());
 	}
 }

--- a/src/main/java/com/digitalsanctuary/spring/user/dto/LockAccountDto.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/dto/LockAccountDto.java
@@ -1,0 +1,13 @@
+package com.digitalsanctuary.spring.user.dto;
+
+import lombok.Data;
+
+/**
+ * A lock account dto. This object is used for locking a user account.
+ */
+@Data
+public class LockAccountDto {
+
+    /** The user's email */
+    private String email;
+}

--- a/src/main/java/com/digitalsanctuary/spring/user/security/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/security/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,45 @@
+package com.digitalsanctuary.spring.user.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Custom authentication failure handler to handle different authentication exceptions.
+ * Specifically handles {@link LockedException} to redirect with a specific error message
+ * for locked accounts. For other authentication failures, it redirects with a generic
+ * invalid credentials message.
+ */
+@Slf4j
+@Component
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler{
+
+    /**
+     * Called when an authentication attempt fails.
+     *
+     * @param request        the request during which the authentication attempt occurred.
+     * @param response       the response.
+     * @param exception      the exception which caused the authentication failure.
+     * @throws IOException      in the event of an I/O error
+     * @throws ServletException in the event of a servlet related error
+     */
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        if (exception instanceof LockedException) {
+            request.getSession().setAttribute("error.message", "Your account is locked. Please contact support.");
+            response.sendRedirect("/login?error=locked");
+        } else {
+            request.getSession().setAttribute("error.message", "Invalid username or password.");
+            response.sendRedirect("/login?error=true");
+        }
+    }
+}

--- a/src/main/java/com/digitalsanctuary/spring/user/security/WebSecurityConfig.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/security/WebSecurityConfig.java
@@ -116,6 +116,7 @@ public class WebSecurityConfig {
 	private final RolesAndPrivilegesConfig rolesAndPrivilegesConfig;
 	private final DSOAuth2UserService dsOAuth2UserService;
 	private final DSOidcUserService dsOidcUserService;
+	private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
 
 	/**
 	 *
@@ -133,7 +134,7 @@ public class WebSecurityConfig {
 		log.debug("WebSecurityConfig.configure: enhanced unprotectedURIs: {}", unprotectedURIs.toString());
 
 		http.formLogin(
-				formLogin -> formLogin.loginPage(loginPageURI).loginProcessingUrl(loginActionURI).successHandler(loginSuccessService).permitAll())
+				formLogin -> formLogin.loginPage(loginPageURI).loginProcessingUrl(loginActionURI).successHandler(loginSuccessService).failureHandler(customAuthenticationFailureHandler).permitAll())
 				.rememberMe(withDefaults());
 
 		http.logout(logout -> logout.logoutUrl(logoutActionURI).logoutSuccessUrl(logoutSuccessURI).invalidateHttpSession(true)

--- a/src/main/java/com/digitalsanctuary/spring/user/service/UserService.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/service/UserService.java
@@ -409,23 +409,53 @@ public class UserService {
 	}
 
 	/**
-	 * Toggle user's lock status. Lock if the user is not locked and unlock if user is locked.
+	 * Locks a user's account.
 	 *
 	 * @param email The email of the user.
 	 */
-	public void toggleLockStatus(String email) {
-		log.debug("UserService.toggleLockStatus: toggling lock status for: {}", email);
+	public void lockAccount(String email) {
+		log.debug("UserService.lockAccount: locking user account for: {}", email);
 		User user = userRepository.findByEmail(email);
 		if (user == null) {
-			log.error("UserService.toggleLockStatus: user not found: {}", email);
+			log.error("UserService.lockAccount: user not found: {}", email);
 			throw new UsernameNotFoundException("User not found: " + email);
 		}
 
-		user.setLocked(!user.isLocked());
-		user.setLockedDate(user.isLocked() ? new java.util.Date() : null);
+		if (user.isLocked()) {
+			log.warn("UserService.lockAccount: user is already locked: {}", email);
+			return;
+		}
+
+		user.setLocked(true);
+		user.setLockedDate(new java.util.Date());
 		userRepository.save(user);
-		log.debug("UserService.toggleLockStatus: user account lock status toggled: {}", email);
+		log.info("UserService.lockAccount: user account locked: {}", email);
 	}
+
+	/**
+	 * Unlocks a user's account.
+	 *
+	 * @param email The email of the user.
+	 */
+	public void unlockAccount(String email) {
+		log.debug("UserService.unlockAccount: unlocking user account for: {}", email);
+		User user = userRepository.findByEmail(email);
+		if (user == null) {
+			log.error("UserService.unlockAccount: user not found: {}", email);
+			throw new UsernameNotFoundException("User not found: " + email);
+		}
+
+		if (!user.isLocked()) {
+			log.warn("UserService.unlockAccount: user is already unlocked: {}", email);
+			return;
+		}
+
+		user.setLocked(false);
+		user.setLockedDate(null);
+		userRepository.save(user);
+		log.info("UserService.unlockAccount: user account unlocked: {}", email);
+	}
+
 
 	/**
 	 * Authenticates the user by creating an authentication object and setting it in the security context.

--- a/src/main/java/com/digitalsanctuary/spring/user/service/UserService.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/service/UserService.java
@@ -409,6 +409,25 @@ public class UserService {
 	}
 
 	/**
+	 * Toggle user's lock status. Lock if the user is not locked and unlock if user is locked.
+	 *
+	 * @param email The email of the user.
+	 */
+	public void toggleLockStatus(String email) {
+		log.debug("UserService.toggleLockStatus: toggling lock status for: {}", email);
+		User user = userRepository.findByEmail(email);
+		if (user == null) {
+			log.error("UserService.toggleLockStatus: user not found: {}", email);
+			throw new UsernameNotFoundException("User not found: " + email);
+		}
+
+		user.setLocked(!user.isLocked());
+		user.setLockedDate(user.isLocked() ? new java.util.Date() : null);
+		userRepository.save(user);
+		log.debug("UserService.toggleLockStatus: user account lock status toggled: {}", email);
+	}
+
+	/**
 	 * Authenticates the user by creating an authentication object and setting it in the security context.
 	 *
 	 * @param userDetails The user details.
@@ -436,7 +455,4 @@ public class UserService {
 		// Store the security context in the session
 		session.setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
 	}
-
-
-
 }

--- a/src/main/java/com/digitalsanctuary/spring/user/util/ResponseUtil.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/util/ResponseUtil.java
@@ -1,0 +1,33 @@
+package com.digitalsanctuary.spring.user.util;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Utility class for creating JSON response.
+ */
+public class ResponseUtil {
+
+    /**
+     * Builds an error response.
+     *
+     * @param message
+     * @param code
+     * @param status
+     * @return a ResponseEntity containing a JSONResponse with the error response
+     */
+    public static ResponseEntity<JSONResponse> buildErrorResponse(String message, int code, HttpStatus status) {
+        return ResponseEntity.status(status).body(JSONResponse.builder().success(false).code(code).message(message).build());
+    }
+
+    /**
+     * Builds a success response.
+     *
+     * @param message
+     * @param redirectUrl
+     * @return a ResponseEntity containing a JSONResponse with the success response
+     */
+    public static ResponseEntity<JSONResponse> buildSuccessResponse(String message, String redirectUrl) {
+        return ResponseEntity.ok(JSONResponse.builder().success(true).code(0).message(message).redirectUrl(redirectUrl).build());
+    }
+}

--- a/src/test/java/com/digitalsanctuary/spring/user/api/AdminApiTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/AdminApiTest.java
@@ -4,7 +4,7 @@ import com.digitalsanctuary.spring.user.api.data.ApiTestData;
 import com.digitalsanctuary.spring.user.api.data.DataStatus;
 import com.digitalsanctuary.spring.user.api.data.Response;
 import com.digitalsanctuary.spring.user.api.helper.AssertionsHelper;
-import com.digitalsanctuary.spring.user.api.provider.ApiTestLockAccountArgumentsProvider;
+import com.digitalsanctuary.spring.user.api.provider.ApiTestAccountLockingArgumentsProvider;
 import com.digitalsanctuary.spring.user.api.provider.holder.ApiTestArgumentsHolder;
 import com.digitalsanctuary.spring.user.dto.UserDto;
 import com.digitalsanctuary.spring.user.jdbc.Jdbc;
@@ -19,7 +19,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 // Disabling the test cases for now because of java.lang.NoClassDefFoundError: org/springframework/security/oauth2/core/user/OAuth2User
-@Disabled("Temporarily disabled due to OAuth2 dependency issues")
+//@Disabled("Temporarily disabled due to OAuth2 dependency issues")
 public class AdminApiTest extends BaseApiTest {
     private static final String URL = "/admin";
     private static final UserDto baseAdminUser = ApiTestData.BASE_ADMIN_USER;
@@ -37,23 +37,44 @@ public class AdminApiTest extends BaseApiTest {
      * @throws Exception testing with 3 params: existing email, non-existing email, no email
      */
     @ParameterizedTest
-    @ArgumentsSource(ApiTestLockAccountArgumentsProvider.class)
+    @ArgumentsSource(ApiTestAccountLockingArgumentsProvider.class)
     public void toggleLockStatusOfUser(ApiTestArgumentsHolder argumentsHolder) throws Exception {
-        ResultActions action = perform(MockMvcRequestBuilders.post(URL + "/lock").contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        ResultActions action = perform(MockMvcRequestBuilders.post(URL + "/lockAccount").contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .content(String.valueOf(argumentsHolder.getLockAccountDto())));
 
+        verifyResponse(action, argumentsHolder);
+    }
+
+    /**
+     * Test unlocking a user account with different conditions (valid, not found, invalid).
+     *
+     * @param argumentsHolder Test data including valid, not found, and invalid cases.
+     * @throws Exception when the test fails
+     */
+    @ParameterizedTest
+    @ArgumentsSource(ApiTestAccountLockingArgumentsProvider.class)
+    public void unlockUserAccount(ApiTestArgumentsHolder argumentsHolder) throws Exception {
+        ResultActions action = perform(MockMvcRequestBuilders.post(URL + "/unlock")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(String.valueOf(argumentsHolder.getLockAccountDto())));
+
+        verifyResponse(action, argumentsHolder);
+    }
+
+    /**
+     * Helper method to verify API responses based on test data.
+     */
+    private void verifyResponse(ResultActions action, ApiTestArgumentsHolder argumentsHolder) throws Exception {
         if (argumentsHolder.getStatus() == DataStatus.VALID) {
             action.andExpect(status().isOk());
-        }
-        if (argumentsHolder.getStatus() == DataStatus.NOT_FOUND) {
+        } else if (argumentsHolder.getStatus() == DataStatus.NOT_FOUND) {
             action.andExpect(status().isNotFound());
-        }
-        if (argumentsHolder.getStatus() == DataStatus.INVALID) {
+        } else if (argumentsHolder.getStatus() == DataStatus.INVALID) {
             action.andExpect(status().isBadRequest());
         }
 
         MockHttpServletResponse actual = action.andReturn().getResponse();
-        Response excepted = argumentsHolder.getResponse();
-        AssertionsHelper.compareResponses(actual, excepted);
+        Response expected = argumentsHolder.getResponse();
+        AssertionsHelper.compareResponses(actual, expected);
     }
 }

--- a/src/test/java/com/digitalsanctuary/spring/user/api/AdminApiTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/AdminApiTest.java
@@ -54,7 +54,7 @@ public class AdminApiTest extends BaseApiTest {
     @ParameterizedTest
     @ArgumentsSource(ApiTestAccountLockingArgumentsProvider.class)
     public void unlockUserAccount(ApiTestArgumentsHolder argumentsHolder) throws Exception {
-        ResultActions action = perform(MockMvcRequestBuilders.post(URL + "/unlock")
+        ResultActions action = perform(MockMvcRequestBuilders.post(URL + "/unlockAccount")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(String.valueOf(argumentsHolder.getLockAccountDto())));
 

--- a/src/test/java/com/digitalsanctuary/spring/user/api/AdminApiTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/AdminApiTest.java
@@ -1,0 +1,59 @@
+package com.digitalsanctuary.spring.user.api;
+
+import com.digitalsanctuary.spring.user.api.data.ApiTestData;
+import com.digitalsanctuary.spring.user.api.data.DataStatus;
+import com.digitalsanctuary.spring.user.api.data.Response;
+import com.digitalsanctuary.spring.user.api.helper.AssertionsHelper;
+import com.digitalsanctuary.spring.user.api.provider.ApiTestLockAccountArgumentsProvider;
+import com.digitalsanctuary.spring.user.api.provider.holder.ApiTestArgumentsHolder;
+import com.digitalsanctuary.spring.user.dto.UserDto;
+import com.digitalsanctuary.spring.user.jdbc.Jdbc;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+// Disabling the test cases for now because of java.lang.NoClassDefFoundError: org/springframework/security/oauth2/core/user/OAuth2User
+@Disabled("Temporarily disabled due to OAuth2 dependency issues")
+public class AdminApiTest extends BaseApiTest {
+    private static final String URL = "/admin";
+    private static final UserDto baseAdminUser = ApiTestData.BASE_ADMIN_USER;
+    private static final UserDto baseTestUser = ApiTestData.BASE_TEST_USER;
+
+    @AfterAll
+    public static void afterAll() {
+        Jdbc.deleteTestUser(baseAdminUser);
+        Jdbc.deleteTestUser(baseTestUser);
+    }
+
+    /**
+     *
+     * @param argumentsHolder
+     * @throws Exception testing with 3 params: existing email, non-existing email, no email
+     */
+    @ParameterizedTest
+    @ArgumentsSource(ApiTestLockAccountArgumentsProvider.class)
+    public void toggleLockStatusOfUser(ApiTestArgumentsHolder argumentsHolder) throws Exception {
+        ResultActions action = perform(MockMvcRequestBuilders.post(URL + "/lock").contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .content(String.valueOf(argumentsHolder.getLockAccountDto())));
+
+        if (argumentsHolder.getStatus() == DataStatus.VALID) {
+            action.andExpect(status().isOk());
+        }
+        if (argumentsHolder.getStatus() == DataStatus.NOT_FOUND) {
+            action.andExpect(status().isNotFound());
+        }
+        if (argumentsHolder.getStatus() == DataStatus.INVALID) {
+            action.andExpect(status().isBadRequest());
+        }
+
+        MockHttpServletResponse actual = action.andReturn().getResponse();
+        Response excepted = argumentsHolder.getResponse();
+        AssertionsHelper.compareResponses(actual, excepted);
+    }
+}

--- a/src/test/java/com/digitalsanctuary/spring/user/api/data/ApiTestData.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/data/ApiTestData.java
@@ -1,12 +1,17 @@
 package com.digitalsanctuary.spring.user.api.data;
 
+import com.digitalsanctuary.spring.user.dto.LockAccountDto;
 import com.digitalsanctuary.spring.user.dto.PasswordDto;
 import com.digitalsanctuary.spring.user.dto.UserDto;
+import com.digitalsanctuary.spring.user.persistence.model.Role;
 import com.digitalsanctuary.spring.user.service.DSUserDetails;
+
+import java.util.Collections;
 
 public class ApiTestData {
 
     public static final UserDto BASE_TEST_USER = getUserDto();
+    public static final UserDto BASE_ADMIN_USER = getAdminUserDto();
     public static final DSUserDetails DEFAULT_DETAILS = new DSUserDetails(null, null);
 
     public static PasswordDto getPasswordDto() {
@@ -34,6 +39,32 @@ public class ApiTestData {
     }
     public static UserDto getEmptyUserDto() {
         return new UserDto();
+    }
+    public static UserDto getAdminUserDto() {
+        UserDto userDto = new UserDto();
+        userDto.setFirstName("testApiAdmin");
+        userDto.setLastName("userApiTest");
+        userDto.setEmail("testApiAdmin@bk.com");
+        userDto.setPassword("testApiAdminPassword");
+        userDto.setMatchingPassword(userDto.getPassword());
+        userDto.setRole(2);
+        return userDto;
+    }
+
+    public static LockAccountDto getLockAccountDto() {
+        LockAccountDto lockAccountDto = new LockAccountDto();
+        lockAccountDto.setEmail("testApiUser@bk.com");
+        return lockAccountDto;
+    }
+
+    public static LockAccountDto getEmptyLockAccountDto() {
+      return new LockAccountDto();
+    }
+
+    public static LockAccountDto getLockAccountDtoForMissingUser() {
+        LockAccountDto lockAccountDto = new LockAccountDto();
+        lockAccountDto.setEmail("testRandom@bk.com");
+        return lockAccountDto;
     }
 
     public static Response successRegistration() {
@@ -90,6 +121,21 @@ public class ApiTestData {
     public static Response deleteAccountFailry() {
         return new Response(false, 2, null,
                 new String[]{"Error Occurred"}, null
+        );
+    }
+    public static Response successLockAccount() {
+        return new Response(true, null, null,
+                new String[]{"Account Locked"}, null
+        );
+    }
+    public static Response lockAccountFailry() {
+        return new Response(false, null, null,
+                new String[]{"User not found"}, null
+        );
+    }
+    public static Response invalidBodyLockAccountFailry() {
+        return new Response(false, 1, null,
+                new String[]{"Email is required"}, null
         );
     }
 }

--- a/src/test/java/com/digitalsanctuary/spring/user/api/data/DataStatus.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/data/DataStatus.java
@@ -6,5 +6,6 @@ public enum DataStatus {
     INVALID,
     VALID,
     LOGGED,
-    NOT_LOGGED
+    NOT_LOGGED,
+    NOT_FOUND
 }

--- a/src/test/java/com/digitalsanctuary/spring/user/api/provider/ApiTestAccountLockingArgumentsProvider.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/provider/ApiTestAccountLockingArgumentsProvider.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 
 import java.util.stream.Stream;
 
-public class ApiTestLockAccountArgumentsProvider implements ArgumentsProvider {
+public class ApiTestAccountLockingArgumentsProvider implements ArgumentsProvider {
   @Override
   public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
     return Stream.of(

--- a/src/test/java/com/digitalsanctuary/spring/user/api/provider/ApiTestLockAccountArgumentsProvider.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/provider/ApiTestLockAccountArgumentsProvider.java
@@ -1,0 +1,35 @@
+package com.digitalsanctuary.spring.user.api.provider;
+
+import com.digitalsanctuary.spring.user.api.data.ApiTestData;
+import com.digitalsanctuary.spring.user.api.data.DataStatus;
+import com.digitalsanctuary.spring.user.api.provider.holder.ApiTestArgumentsHolder;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+public class ApiTestLockAccountArgumentsProvider implements ArgumentsProvider {
+  @Override
+  public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+    return Stream.of(
+            new ApiTestArgumentsHolder(
+                    ApiTestData.getLockAccountDto(),
+                    DataStatus.VALID,
+                    ApiTestData.successLockAccount()
+            ),
+
+            new ApiTestArgumentsHolder(
+                    ApiTestData.getEmptyLockAccountDto(),
+                    DataStatus.INVALID,
+                    ApiTestData.invalidBodyLockAccountFailry()
+            ),
+
+            new ApiTestArgumentsHolder(
+                    ApiTestData.getLockAccountDtoForMissingUser(),
+                    DataStatus.NOT_FOUND,
+                    ApiTestData.lockAccountFailry()
+            )
+    ).map(Arguments::of);
+  }
+}

--- a/src/test/java/com/digitalsanctuary/spring/user/api/provider/holder/ApiTestArgumentsHolder.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/provider/holder/ApiTestArgumentsHolder.java
@@ -2,6 +2,7 @@ package com.digitalsanctuary.spring.user.api.provider.holder;
 
 import com.digitalsanctuary.spring.user.api.data.DataStatus;
 import com.digitalsanctuary.spring.user.api.data.Response;
+import com.digitalsanctuary.spring.user.dto.LockAccountDto;
 import com.digitalsanctuary.spring.user.dto.PasswordDto;
 import com.digitalsanctuary.spring.user.dto.UserDto;
 
@@ -9,6 +10,7 @@ public class ApiTestArgumentsHolder {
 
     private UserDto userDto;
     private PasswordDto passwordDto;
+    private LockAccountDto lockAccountDto;
     private final DataStatus status;
     private final Response response;
 
@@ -30,12 +32,22 @@ public class ApiTestArgumentsHolder {
         this.response = response;
     }
 
+    public ApiTestArgumentsHolder(LockAccountDto lockAccountDto, DataStatus status, Response response) {
+        this.lockAccountDto = lockAccountDto;
+        this.status = status;
+        this.response = response;
+    }
+
     public UserDto getUserDto() {
         return userDto;
     }
 
     public DataStatus getStatus() {
         return status;
+    }
+
+    public LockAccountDto getLockAccountDto() {
+        return lockAccountDto;
     }
 
     public Response getResponse() {


### PR DESCRIPTION
This pull request introduces a new REST API endpoint `/admin/toggleLockStatus` that allows adminsto toggle the lock status of a user account.

Key changes include:

- Creation of the `toggleLockStatus` POST endpoint under the `/admin` path.
- Implementation of the endpoint to receive a `LockAccountDto` containing the user's email.
- Integration with the `UserService` to perform the logic of toggling the account lock status.
- Implementation of input validation for the `LockAccountDto` to ensure the email is provided.
- Implementation of proper error handling for scenarios such as user not found and invalid input, returning appropriate HTTP status codes and JSON responses.

Link to the issue: https://github.com/devondragon/SpringUserFramework/issues/32