### PR TITLE
Refactor conditional annotation in FileAuditLogFlushScheduler to use …

### DIFF
--- a/src/main/java/com/digitalsanctuary/spring/user/audit/FileAuditLogFlushScheduler.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/audit/FileAuditLogFlushScheduler.java
@@ -1,6 +1,6 @@
 package com.digitalsanctuary.spring.user.audit;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "user.audit.flushOnWrite", havingValue = "false")
+@ConditionalOnExpression("${user.audit.logEvents:true} && !${user.audit.flushOnWrite:true}")
 public class FileAuditLogFlushScheduler {
 
     /**


### PR DESCRIPTION

This pull request updates the conditional logic for enabling the `FileAuditLogFlushScheduler` component to provide more flexibility in configuration. The most important changes are:

### Updates to conditional annotations:

* Replaced `@ConditionalOnProperty` with `@ConditionalOnExpression` in `FileAuditLogFlushScheduler` to allow more complex conditions for enabling the scheduler. The new condition checks that `user.audit.logEvents` is true and `user.audit.flushOnWrite` is not true. (`src/main/java/com/digitalsanctuary/spring/user/audit/FileAuditLogFlushScheduler.java`, [[1]](diffhunk://#diff-0ffbf0dab2e4d322eb52a7dbeb5c8cae9f00e8428dd07937c8283882c117050aL3-R3) [[2]](diffhunk://#diff-0ffbf0dab2e4d322eb52a7dbeb5c8cae9f00e8428dd07937c8283882c117050aL16-R16)