### PR TITLE
Bump version to 3.5.0-SNAPSHOT; add VS Code Java home settings; use A…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,7 @@
     "debug.javascript.defaultRuntimeExecutable": {
         "pwa-node": "/Users/devon/.local/share/mise/shims/node"
     },
-    "python.defaultInterpreterPath": "/Users/devon/.local/share/mise/installs/python/3.13.2/bin/python"
+    "python.defaultInterpreterPath": "/Users/devon/.local/share/mise/installs/python/3.13.2/bin/python",
+    "java.jdt.ls.java.home": "/Users/devon/.local/share/mise/installs/java/17.0.2",
+    "java.import.gradle.java.home": "/Users/devon/.local/share/mise/installs/java/17.0.2"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=3.4.2-SNAPSHOT
+version=3.5.0-SNAPSHOT
 mavenCentralPublishing=true
 mavenCentralAutomaticPublishing=true

--- a/src/main/java/com/digitalsanctuary/spring/user/service/PasswordPolicyService.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/service/PasswordPolicyService.java
@@ -16,6 +16,7 @@ import org.passay.RuleResult;
 import org.passay.dictionary.ArrayWordList;
 import org.passay.dictionary.WordListDictionary;
 import org.passay.dictionary.WordLists;
+import org.passay.dictionary.sort.ArraysSort;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.core.io.Resource;
@@ -100,7 +101,7 @@ public class PasswordPolicyService {
             try (
                     Reader reader = new BufferedReader(
                             new InputStreamReader(commonPasswordsResource.getInputStream()))) {
-                ArrayWordList wordList = WordLists.createFromReader(new Reader[] { reader }, false);
+                ArrayWordList wordList = WordLists.createFromReader(new Reader[] { reader }, false, new ArraysSort());
                 WordListDictionary dictionary = new WordListDictionary(wordList);
                 commonPasswordRule = new DictionaryRule(dictionary);
                 log.info("Common password dictionary initialized successfully.");


### PR DESCRIPTION
This pull request updates Java development environment settings, bumps the project version, and improves password policy enforcement by ensuring the common password list is sorted. The most significant changes are grouped below.

**Development environment updates:**

* Updated `.vscode/settings.json` to set the Java home directory for language support and Gradle import tasks, ensuring consistent Java version usage in VSCode.

**Project versioning:**

* Bumped the project version in `gradle.properties` from `3.4.2-SNAPSHOT` to `3.5.0-SNAPSHOT` to mark the start of a new development cycle.

**Password policy improvements:**

* Modified `PasswordPolicyService.java` to import `ArraysSort` and use it when creating the `ArrayWordList` for the common password dictionary, ensuring the word list is sorted for more efficient lookups. [[1]](diffhunk://#diff-ea416a685a03b20762a04af0bb51d4c4573e105c31a18b3a58085805c98a9c53R19) [[2]](diffhunk://#diff-ea416a685a03b20762a04af0bb51d4c4573e105c31a18b3a58085805c98a9c53L103-R104)…rraysSort for Passay wordlist initialization