### PR TITLE
Update major test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.retry:spring-retry:2.0.12'
     testImplementation 'jakarta.validation:jakarta.validation-api:3.1.1'
-    testImplementation 'org.hibernate.validator:hibernate-validator:8.0.2.Final'
+    testImplementation 'org.hibernate.validator:hibernate-validator:9.1.0.Final'
     testImplementation 'com.h2database:h2:2.4.240'
 
     // Spring Boot 4 test starters (modular test infrastructure)
@@ -86,12 +86,12 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql'
 
     // Additional test dependencies for improved testing
-    testImplementation 'org.testcontainers:testcontainers:1.21.3'
-    testImplementation 'org.testcontainers:mariadb:1.21.3'
+    testImplementation 'org.testcontainers:testcontainers:2.0.2'
+    testImplementation 'org.testcontainers:testcontainers-mariadb:2.0.2'
     testImplementation 'com.github.tomakehurst:wiremock:3.0.1'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.1'
     testImplementation 'org.assertj:assertj-core:3.27.6'
-    testImplementation 'io.rest-assured:rest-assured:5.5.6'
+    testImplementation 'io.rest-assured:rest-assured:6.0.0'
     testImplementation 'com.icegreen:greenmail:2.1.8'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }


### PR DESCRIPTION
## Summary
- Update hibernate-validator: 8.0.2.Final → 9.1.0.Final
- Update testcontainers: 1.21.3 → 2.0.2 (artifact `mariadb` renamed to `testcontainers-mariadb`)
- Update rest-assured: 5.5.6 → 6.0.0

## Deferred
Milestone versions skipped for now:
- jakarta.validation-api 4.0.0-M1
- assertj-core 4.0.0-M1

## Test plan
- [x] All existing tests pass with updated dependencies

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)