### PR TITLE
refactor(security): extract WebAuthn ObjectPostProcessor into helper method

### DIFF
--- a/src/main/java/com/digitalsanctuary/spring/user/security/WebSecurityConfig.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/security/WebSecurityConfig.java
@@ -232,7 +232,7 @@ public class WebSecurityConfig {
 	/**
 	 * Creates an ObjectPostProcessor that sets our custom WebAuthn success handler on the WebAuthnAuthenticationFilter.
 	 *
-	 * @return the post processor
+	 * @return an ObjectPostProcessor that injects a custom authentication success handler
 	 */
 	private ObjectPostProcessor<WebAuthnAuthenticationFilter> webAuthnSuccessHandlerPostProcessor() {
 		return new ObjectPostProcessor<WebAuthnAuthenticationFilter>() {


### PR DESCRIPTION
## Summary
- Extract inline anonymous `ObjectPostProcessor` from `setupWebAuthn()` into a private `webAuthnSuccessHandlerPostProcessor()` helper method
- Add proper imports for `ObjectPostProcessor` and `WebAuthnAuthenticationFilter`, removing fully-qualified type names
- Align with the concise, method-extracted style used throughout the rest of `WebSecurityConfig`

Closes #255

## Test plan
- [x] `./gradlew compileJava compileTestJava` passes
- [x] `./gradlew test --tests '*WebAuthn*'` — all 4 WebAuthn tests pass
- [ ] Full test suite via CI