### PR TITLE
fix: make mail truly optional and clarify quick-start docs (#310)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,13 @@ Follow these steps to get up and running with the Spring User Framework in your 
        <artifactId>spring-boot-starter-security</artifactId>
    </dependency>
    <dependency>
+       <groupId>org.springframework.boot</groupId>
+       <artifactId>spring-boot-starter-oauth2-client</artifactId>
+   </dependency>
+   <dependency>
        <groupId>org.springframework.retry</groupId>
        <artifactId>spring-retry</artifactId>
+       <version>2.0.12</version>
    </dependency>
    ```
 
@@ -251,8 +256,13 @@ Follow these steps to get up and running with the Spring User Framework in your 
    implementation 'org.springframework.boot:spring-boot-starter-mail'
    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
    implementation 'org.springframework.boot:spring-boot-starter-security'
-   implementation 'org.springframework.retry:spring-retry'
+   implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+   implementation 'org.springframework.retry:spring-retry:2.0.12'
    ```
+
+   **Notes:**
+   - `spring-boot-starter-oauth2-client` is required even if you don't plan to enable social login. The framework's security chain wires OAuth2 user services at startup; the dependency must be on the classpath so the classes resolve. OAuth2 login itself remains disabled by default (`spring.security.oauth2.enabled=false`).
+   - `spring-retry` needs an explicit version because Spring Boot's BOM may not manage this artifact. The version shown matches what the framework is built against.
 
 ### Step 2: Database Configuration
 
@@ -298,7 +308,7 @@ spring:
 
 ### Step 4: Email Configuration (Optional but Recommended)
 
-For password reset and email verification features:
+If `spring.mail.host` is not configured, the framework starts cleanly but any feature that would send mail (password reset, registration verification) logs a warning and silently skips the send. Configure mail when you want those features to actually deliver messages:
 
 ```yaml
 spring:
@@ -384,17 +394,24 @@ public class AppUserProfile extends BaseUserProfile {
 - Navigate to `/user/login.html`
 - Use the credentials you just created
 
-### Step 9: Customize Pages (Optional)
+### Step 9: Customize Pages (Required for user-facing pages)
 
-The framework provides default HTML templates, but you can override them:
+The framework ships email templates (`templates/mail/*.html`) but does **not** ship the user-facing HTML pages (login, register, forgot-password, etc). You provide those yourself, typically by copying the reference set from the demo app and styling them to match your app.
 
-1. **Create custom templates** in `src/main/resources/templates/user/`:
+1. **Grab the reference templates** from [SpringUserFrameworkDemoApp/src/main/resources/templates/user/](https://github.com/devondragon/SpringUserFrameworkDemoApp/tree/main/src/main/resources/templates/user) and drop them into `src/main/resources/templates/user/` in your project:
    - `login.html` - Login page
    - `register.html` - Registration page
-   - `forgot-password.html` - Password reset page
-   - And more...
+   - `forgot-password.html` - Password reset request
+   - `forgot-password-change.html` - Password reset form
+   - `update-password.html` - Authenticated password change
+   - `update-user.html` - Profile update
+   - `registration-complete.html`, `registration-pending-verification.html`, `request-new-verification-email.html`, `forgot-password-pending-verification.html`, `delete-account.html`
 
-2. **Use your own CSS** by adding stylesheets to `src/main/resources/static/css/`
+   The demo's templates use a Thymeleaf layout (`layout.html`) and shared fragments. If you don't want that, strip the `layout:decorate` / `th:fragment` references and inline the markup.
+
+2. **Use your own CSS** by adding stylesheets to `src/main/resources/static/css/`.
+
+The framework only requires that the templates exist at the URLs configured under `user.security.*` (e.g. `loginPageURI`, `registrationURI`) and post back to the matching `/user/*` API endpoints; the HTML structure inside them is yours.
 
 ### Complete Example Configuration
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Follow these steps to get up and running with the Spring User Framework in your 
    ```
 
    **Notes:**
-   - `spring-boot-starter-oauth2-client` is required even if you don't plan to enable social login. The framework's security chain wires OAuth2 user services at startup; the dependency must be on the classpath so the classes resolve. OAuth2 login itself remains disabled by default (`spring.security.oauth2.enabled=false`).
+   - `spring-boot-starter-oauth2-client` is required even if you don't plan to use social login. The framework's security chain wires OAuth2 user services at startup; the dependency must be on the classpath so the classes resolve. The OAuth2 login flow itself is disabled by default and opt-in — set `spring.security.oauth2.enabled=true` in your application properties only when you configure OAuth2 provider credentials (this is a framework property, not a standard Spring Security key).
    - `spring-retry` needs an explicit version because Spring Boot's BOM may not manage this artifact. The version shown matches what the framework is built against.
 
 ### Step 2: Database Configuration

--- a/src/main/java/com/digitalsanctuary/spring/user/mail/MailService.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/mail/MailService.java
@@ -1,6 +1,7 @@
 package com.digitalsanctuary.spring.user.mail;
 
 import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -17,13 +18,16 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * The MailService provides outbound email sending services on top of the Spring mail framework, and leverages Thymeleaf templates for rich dynamic
  * emails.
+ *
+ * <p>Email is treated as optional: if no {@link JavaMailSender} bean is available (typically because {@code spring.mail.host} is not configured),
+ * send operations log a warning and return without throwing, so the application starts and runs normally with email-dependent features degraded.</p>
  */
 @Slf4j
 @Service
 public class MailService {
 
-	/** The mail sender. */
-	private final JavaMailSender mailSender;
+	/** Provider for the mail sender — resolved lazily so the bean is optional. */
+	private final ObjectProvider<JavaMailSender> mailSenderProvider;
 
 	/** The mail content builder. */
 	private final MailContentBuilder mailContentBuilder;
@@ -35,12 +39,26 @@ public class MailService {
 	/**
 	 * Instantiates a new mail service.
 	 *
-	 * @param mailSender the mail sender
+	 * @param mailSenderProvider provider for the mail sender; may resolve to null when mail is not configured
 	 * @param mailContentBuilder the mail content builder
 	 */
-	public MailService(JavaMailSender mailSender, MailContentBuilder mailContentBuilder) {
-		this.mailSender = mailSender;
+	public MailService(ObjectProvider<JavaMailSender> mailSenderProvider, MailContentBuilder mailContentBuilder) {
+		this.mailSenderProvider = mailSenderProvider;
 		this.mailContentBuilder = mailContentBuilder;
+	}
+
+	/**
+	 * Resolve the {@link JavaMailSender}, or log a warning and return null when none is available.
+	 *
+	 * @param to the recipient (for log context only)
+	 * @return the sender, or {@code null} if not configured
+	 */
+	private JavaMailSender resolveMailSender(String to) {
+		JavaMailSender sender = mailSenderProvider.getIfAvailable();
+		if (sender == null) {
+			log.warn("Email send to '{}' skipped: JavaMailSender is not configured. Set 'spring.mail.host' to enable email sending.", to);
+		}
+		return sender;
 	}
 
 	/**
@@ -51,11 +69,16 @@ public class MailService {
 	 * @param text the text to include as the email message body
 	 */
 	@Async
-	@Retryable(retryFor = {MailException.class}, maxAttempts = 3, 
+	@Retryable(retryFor = {MailException.class}, maxAttempts = 3,
 			   backoff = @Backoff(delay = 1000, multiplier = 2))
 	public void sendSimpleMessage(String to, String subject, String text) {
 		log.debug("Attempting to send simple email to: {}", to);
-		
+
+		JavaMailSender sender = resolveMailSender(to);
+		if (sender == null) {
+			return;
+		}
+
 		MimeMessagePreparator messagePreparator = mimeMessage -> {
 			MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
 			messageHelper.setFrom(fromAddress);
@@ -64,7 +87,7 @@ public class MailService {
 			messageHelper.setText(text, true);
 		};
 
-		mailSender.send(messagePreparator);
+		sender.send(messagePreparator);
 		log.debug("Successfully sent simple email to: {}", to);
 	}
 
@@ -77,11 +100,16 @@ public class MailService {
 	 * @param templatePath the file name, or path and name, for the Thymeleaf template to use to build the dynamic email
 	 */
 	@Async
-	@Retryable(retryFor = {MailException.class}, maxAttempts = 3, 
+	@Retryable(retryFor = {MailException.class}, maxAttempts = 3,
 			   backoff = @Backoff(delay = 1000, multiplier = 2))
 	public void sendTemplateMessage(String to, String subject, Map<String, Object> variables, String templatePath) {
 		log.debug("Attempting to send template email to: {}, template: {}", to, templatePath);
-		
+
+		JavaMailSender sender = resolveMailSender(to);
+		if (sender == null) {
+			return;
+		}
+
 		MimeMessagePreparator messagePreparator = mimeMessage -> {
 			MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
 			messageHelper.setFrom(fromAddress);
@@ -92,8 +120,8 @@ public class MailService {
 			String content = mailContentBuilder.build(templatePath, context);
 			messageHelper.setText(content, true);
 		};
-		
-		mailSender.send(messagePreparator);
+
+		sender.send(messagePreparator);
 		log.debug("Successfully sent template email to: {}", to);
 	}
 
@@ -107,7 +135,7 @@ public class MailService {
 	 */
 	@Recover
 	public void recoverSendSimpleMessage(MailException ex, String to, String subject, String text) {
-		log.error("Failed to send simple email to {} after all retry attempts. Subject: '{}'. Error: {}", 
+		log.error("Failed to send simple email to {} after all retry attempts. Subject: '{}'. Error: {}",
 				  to, subject, ex.getMessage());
 	}
 
@@ -121,9 +149,9 @@ public class MailService {
 	 * @param templatePath the template path
 	 */
 	@Recover
-	public void recoverSendTemplateMessage(MailException ex, String to, String subject, 
+	public void recoverSendTemplateMessage(MailException ex, String to, String subject,
 										   Map<String, Object> variables, String templatePath) {
-		log.error("Failed to send template email to {} after all retry attempts. Subject: '{}', Template: '{}'. Error: {}", 
+		log.error("Failed to send template email to {} after all retry attempts. Subject: '{}', Template: '{}'. Error: {}",
 				  to, subject, templatePath, ex.getMessage());
 	}
 }

--- a/src/main/java/com/digitalsanctuary/spring/user/mail/MailService.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/mail/MailService.java
@@ -1,6 +1,7 @@
 package com.digitalsanctuary.spring.user.mail;
 
 import java.util.Map;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
@@ -20,17 +21,19 @@ import lombok.extern.slf4j.Slf4j;
  * emails.
  *
  * <p>Email is treated as optional: if no {@link JavaMailSender} bean is available (typically because {@code spring.mail.host} is not configured),
- * send operations log a warning and return without throwing, so the application starts and runs normally with email-dependent features degraded.</p>
+ * a single warning is logged at startup and all send operations silently no-op, so the application starts and runs normally with email-dependent
+ * features degraded.</p>
  */
 @Slf4j
 @Service
 public class MailService {
 
-	/** Provider for the mail sender — resolved lazily so the bean is optional. */
 	private final ObjectProvider<JavaMailSender> mailSenderProvider;
 
-	/** The mail content builder. */
 	private final MailContentBuilder mailContentBuilder;
+
+	/** Resolved once at startup; null when JavaMailSender is not configured. */
+	private JavaMailSender resolvedSender;
 
 	/** The from address. */
 	@Value("${user.mail.fromAddress}")
@@ -48,17 +51,15 @@ public class MailService {
 	}
 
 	/**
-	 * Resolve the {@link JavaMailSender}, or log a warning and return null when none is available.
-	 *
-	 * @param to the recipient (for log context only)
-	 * @return the sender, or {@code null} if not configured
+	 * Resolves and caches the {@link JavaMailSender} once at startup. Logs a single warning when no sender is available so operators are informed
+	 * without flooding logs during normal operation.
 	 */
-	private JavaMailSender resolveMailSender(String to) {
-		JavaMailSender sender = mailSenderProvider.getIfAvailable();
-		if (sender == null) {
-			log.warn("Email send to '{}' skipped: JavaMailSender is not configured. Set 'spring.mail.host' to enable email sending.", to);
+	@PostConstruct
+	void init() {
+		resolvedSender = mailSenderProvider.getIfAvailable();
+		if (resolvedSender == null) {
+			log.warn("JavaMailSender is not configured — email sending is disabled. Set 'spring.mail.host' to enable.");
 		}
-		return sender;
 	}
 
 	/**
@@ -72,12 +73,10 @@ public class MailService {
 	@Retryable(retryFor = {MailException.class}, maxAttempts = 3,
 			   backoff = @Backoff(delay = 1000, multiplier = 2))
 	public void sendSimpleMessage(String to, String subject, String text) {
-		log.debug("Attempting to send simple email to: {}", to);
-
-		JavaMailSender sender = resolveMailSender(to);
-		if (sender == null) {
+		if (resolvedSender == null) {
 			return;
 		}
+		log.debug("Attempting to send simple email to: {}", to);
 
 		MimeMessagePreparator messagePreparator = mimeMessage -> {
 			MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
@@ -87,7 +86,7 @@ public class MailService {
 			messageHelper.setText(text, true);
 		};
 
-		sender.send(messagePreparator);
+		resolvedSender.send(messagePreparator);
 		log.debug("Successfully sent simple email to: {}", to);
 	}
 
@@ -103,12 +102,10 @@ public class MailService {
 	@Retryable(retryFor = {MailException.class}, maxAttempts = 3,
 			   backoff = @Backoff(delay = 1000, multiplier = 2))
 	public void sendTemplateMessage(String to, String subject, Map<String, Object> variables, String templatePath) {
-		log.debug("Attempting to send template email to: {}, template: {}", to, templatePath);
-
-		JavaMailSender sender = resolveMailSender(to);
-		if (sender == null) {
+		if (resolvedSender == null) {
 			return;
 		}
+		log.debug("Attempting to send template email to: {}, template: {}", to, templatePath);
 
 		MimeMessagePreparator messagePreparator = mimeMessage -> {
 			MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
@@ -121,7 +118,7 @@ public class MailService {
 			messageHelper.setText(content, true);
 		};
 
-		sender.send(messagePreparator);
+		resolvedSender.send(messagePreparator);
 		log.debug("Successfully sent template email to: {}", to);
 	}
 

--- a/src/test/java/com/digitalsanctuary/spring/user/mail/MailServiceTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/mail/MailServiceTest.java
@@ -56,9 +56,10 @@ class MailServiceTest {
 
     @BeforeEach
     void setUp() {
-        // Provider returns the mock mailSender by default; individual tests can override to simulate missing config.
+        // Provider returns the mock mailSender by default.
         lenient().when(mailSenderProvider.getIfAvailable()).thenReturn(mailSender);
         mailService = new MailService(mailSenderProvider, mailContentBuilder);
+        mailService.init(); // simulate @PostConstruct — caches the resolved sender
         ReflectionTestUtils.setField(mailService, "fromAddress", FROM_ADDRESS);
 
         // Setup default mock behavior
@@ -514,29 +515,30 @@ class MailServiceTest {
     @DisplayName("Missing JavaMailSender Tests")
     class MissingMailSenderTests {
 
+        private MailService unconfiguredMailService;
+
+        @BeforeEach
+        void setUpUnconfigured() {
+            // Separate service instance where the sender is absent from startup.
+            when(mailSenderProvider.getIfAvailable()).thenReturn(null);
+            unconfiguredMailService = new MailService(mailSenderProvider, mailContentBuilder);
+            unconfiguredMailService.init();
+            ReflectionTestUtils.setField(unconfiguredMailService, "fromAddress", FROM_ADDRESS);
+        }
+
         @Test
         @DisplayName("sendSimpleMessage should no-op when JavaMailSender is not configured")
         void sendSimpleMessageNoOpsWhenSenderMissing() {
-            // Given
-            when(mailSenderProvider.getIfAvailable()).thenReturn(null);
+            unconfiguredMailService.sendSimpleMessage(TO_ADDRESS, SUBJECT, "Body");
 
-            // When
-            mailService.sendSimpleMessage(TO_ADDRESS, SUBJECT, "Body");
-
-            // Then
             verify(mailSender, never()).send(any(MimeMessagePreparator.class));
         }
 
         @Test
         @DisplayName("sendTemplateMessage should no-op when JavaMailSender is not configured")
         void sendTemplateMessageNoOpsWhenSenderMissing() {
-            // Given
-            when(mailSenderProvider.getIfAvailable()).thenReturn(null);
+            unconfiguredMailService.sendTemplateMessage(TO_ADDRESS, SUBJECT, new HashMap<>(), "email/test");
 
-            // When
-            mailService.sendTemplateMessage(TO_ADDRESS, SUBJECT, new HashMap<>(), "email/test");
-
-            // Then
             verify(mailSender, never()).send(any(MimeMessagePreparator.class));
             verify(mailContentBuilder, never()).build(anyString(), any(Context.class));
         }

--- a/src/test/java/com/digitalsanctuary/spring/user/mail/MailServiceTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/mail/MailServiceTest.java
@@ -17,9 +17,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.mail.MailException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -40,12 +40,14 @@ class MailServiceTest {
     private JavaMailSender mailSender;
 
     @Mock
+    private ObjectProvider<JavaMailSender> mailSenderProvider;
+
+    @Mock
     private MailContentBuilder mailContentBuilder;
 
     @Mock
     private MimeMessage mimeMessage;
 
-    @InjectMocks
     private MailService mailService;
 
     private static final String FROM_ADDRESS = "noreply@example.com";
@@ -54,9 +56,11 @@ class MailServiceTest {
 
     @BeforeEach
     void setUp() {
-        // Set the from address via reflection since it's a @Value field
+        // Provider returns the mock mailSender by default; individual tests can override to simulate missing config.
+        lenient().when(mailSenderProvider.getIfAvailable()).thenReturn(mailSender);
+        mailService = new MailService(mailSenderProvider, mailContentBuilder);
         ReflectionTestUtils.setField(mailService, "fromAddress", FROM_ADDRESS);
-        
+
         // Setup default mock behavior
         lenient().when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
     }
@@ -503,6 +507,38 @@ class MailServiceTest {
             assertThatThrownBy(() -> preparatorCaptor.getValue().prepare(mimeMessage))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Template not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("Missing JavaMailSender Tests")
+    class MissingMailSenderTests {
+
+        @Test
+        @DisplayName("sendSimpleMessage should no-op when JavaMailSender is not configured")
+        void sendSimpleMessageNoOpsWhenSenderMissing() {
+            // Given
+            when(mailSenderProvider.getIfAvailable()).thenReturn(null);
+
+            // When
+            mailService.sendSimpleMessage(TO_ADDRESS, SUBJECT, "Body");
+
+            // Then
+            verify(mailSender, never()).send(any(MimeMessagePreparator.class));
+        }
+
+        @Test
+        @DisplayName("sendTemplateMessage should no-op when JavaMailSender is not configured")
+        void sendTemplateMessageNoOpsWhenSenderMissing() {
+            // Given
+            when(mailSenderProvider.getIfAvailable()).thenReturn(null);
+
+            // When
+            mailService.sendTemplateMessage(TO_ADDRESS, SUBJECT, new HashMap<>(), "email/test");
+
+            // Then
+            verify(mailSender, never()).send(any(MimeMessagePreparator.class));
+            verify(mailContentBuilder, never()).build(anyString(), any(Context.class));
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses the four speed bumps reported in #310:

1. **OAuth2 dependency was undocumented.** `spring-boot-starter-oauth2-client` is unconditionally wired into the security chain (`WebSecurityConfig` injects `DSOAuth2UserService` / `DSOidcUserService` as required constructor params). README now lists it in the required dependencies.

2. **`spring-retry` version resolution.** Spring Boot's BOM doesn't always manage `spring-retry`; pin to `2.0.12` to match what the library is built against (`build.gradle:52`).

3. **Mail config wasn't actually optional.** `MailService` had `JavaMailSender` as a hard constructor dependency, so apps without `spring.mail.host` set wouldn't start. Refactored to take `ObjectProvider<JavaMailSender>` — when the bean is absent, send operations log a warning and no-op. README Step 4 updated to describe the degraded behavior.

4. **No user-facing templates ship.** The library ships only `templates/mail/` (email templates). README Step 9 used to claim "default HTML templates" existed; updated to direct users to the demo app's templates dir.

## Changes

- `src/main/java/com/digitalsanctuary/spring/user/mail/MailService.java` — switch to `ObjectProvider<JavaMailSender>`; add `resolveMailSender()` helper that returns null + warns when absent; bail out of send methods when no sender available.
- `src/test/java/com/digitalsanctuary/spring/user/mail/MailServiceTest.java` — update fixture for new constructor; add two new tests covering the no-sender no-op path.
- `README.md` — Step 1 deps (OAuth2 + retry version + explanatory notes), Step 4 mail (truly optional now), Step 9 templates (link to demo, list the files).

## Test plan

- [x] `./gradlew test --tests "*MailServiceTest"` — all 24 tests pass (2 new)
- [x] `./gradlew test --tests "*UserEmailServiceTest" --tests "*RegistrationListenerTest"` — pass (downstream callers unaffected)
- [x] Full `./gradlew test` — only pre-existing failures remain (`LogoutSuccessServiceTest` Mockito strict-stubbing on `Referer` header, unrelated to this PR)

Closes #310.