### PR TITLE
docs: align README install versions with the 5.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ Choose the version that matches your Spring Boot version:
 
 | Spring Boot Version | Framework Version | Java Version | Spring Security |
 | ------------------- | ----------------- | ------------ | --------------- |
-| 4.0.x – 4.1.x       | 5.1.x             | 21+          | 7.x             |
+| 4.0.x – 4.1.x       | 5.2.x             | 21+          | 7.x             |
 | 3.5.x               | 3.6.x             | 17+          | 6.x             |
 
-> **Versioning note:** This library follows Semantic Versioning for its **own** API; its major version is intentionally **not** aligned with Spring Boot's major version. The 5.0.x line is built and verified against **Spring Boot 4.1.0** and also runs on 4.0.x — all Spring Boot starters are `compileOnly`, so your application picks the exact Spring Boot patch version. The `5.0.x` line is a **breaking release** over `4.4.x`; read the **[Migration Guide](MIGRATION.md)** ("Migrating to 5.0.x") before upgrading — note especially the reverse-proxy `user.security.appUrl` requirement.
+> **Versioning note:** This library follows Semantic Versioning for its **own** API; its major version is intentionally **not** aligned with Spring Boot's major version. The 5.2.x line is built and verified against **Spring Boot 4.1.0** and also runs on 4.0.x — all Spring Boot starters are `compileOnly`, so your application picks the exact Spring Boot patch version. The `5.0.x` line is a **breaking release** over `4.4.x`; read the **[Migration Guide](MIGRATION.md)** ("Migrating to 5.0.x") before upgrading — note especially the reverse-proxy `user.security.appUrl` requirement.
 
 ### Spring Boot 4.x (Latest)
 
@@ -135,13 +135,13 @@ Spring Boot 4.x brings significant changes including Spring Security 7 and requi
 <dependency>
     <groupId>com.digitalsanctuary</groupId>
     <artifactId>ds-spring-user-framework</artifactId>
-    <version>5.1.1</version>
+    <version>5.2.0</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'com.digitalsanctuary:ds-spring-user-framework:5.1.1'
+implementation 'com.digitalsanctuary:ds-spring-user-framework:5.2.0'
 ```
 
 #### Spring Boot 4.x Key Changes
@@ -171,7 +171,7 @@ testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 
 For projects using Spring Boot 3.5.x with Java 17+:
 
-> **Security-maintenance only.** The `3.6.x` line backports security fixes from the 5.0.x line that apply to Spring Boot 3.5; new feature development happens on `5.0.x`. If you are on Java 21 / Spring Boot 4, use `5.0.x`.
+> **Security-maintenance only.** The `3.6.x` line backports security fixes from the 5.x line that apply to Spring Boot 3.5; new feature development happens on `5.2.x`. If you are on Java 21 / Spring Boot 4, use `5.2.x`.
 
 **Maven:**
 ```xml
@@ -214,7 +214,7 @@ Follow these steps to get up and running with the Spring User Framework in your 
 
    **Spring Boot 4.0 / 4.1 (Java 21+):**
    ```groovy
-   implementation 'com.digitalsanctuary:ds-spring-user-framework:5.1.1'
+   implementation 'com.digitalsanctuary:ds-spring-user-framework:5.2.0'
    ```
 
    **Spring Boot 3.5 (Java 17+):**


### PR DESCRIPTION
5.2.0 is published to Maven Central and the GitHub release is up, but the README still pointed users at 5.1.1.

## Changes

- **Compatibility matrix**: the Spring Boot 4.0.x–4.1.x row now reads `5.2.x` (was `5.1.x`).
- **Install snippets**: Maven `<version>` and the Gradle `implementation` line in the Spring Boot 4.x section, plus the Quick Start snippet, now use `5.2.0` (was `5.1.1`).
- **Versioning note**: the line "built and verified against Spring Boot 4.1.0" now names `5.2.x`.
- **Spring Boot 3.5 maintenance note**: points readers at `5.2.x` as the active line for new feature development, and generalizes the backport source to "the 5.x line".

## Deliberately unchanged

- The `4.4.x` → `5.0.x` breaking-release sentence and the `MIGRATION.md` "Migrating to 5.0.x" anchor. Both describe history and a real section heading, not the current line.
- All `3.6.x` references in the Spring Boot 3.5 section — that line is unchanged by this release.

Docs only; no code or build changes.