### PR TITLE
chore: bump ben-manes versions plugin to 0.61.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
-    id 'com.github.ben-manes.versions' version '0.60.0'
+    id 'io.github.ben-manes.versions' version '0.61.0'
     id 'java-library'
     id 'maven-publish'
     id 'signing'


### PR DESCRIPTION
## Summary
Bumps the Gradle dependency-updates plugin and adopts its non-deprecated id.

- `com.github.ben-manes.versions` 0.60.0 → `io.github.ben-manes.versions` 0.61.0

The old `com.github.ben-manes.versions` id is deprecated; the build emitted a configuration-time warning on every run. Switching to `io.github.ben-manes.versions` and bumping to 0.61.0 clears it.

## Context
Ran `./gradlew dependencyUpdates -Drevision=release`. This plugin id/version was the only clean actionable update:
- Spring Boot is already at 4.1.0 (latest); the whole starter set resolved at latest.
- MariaDB / PostgreSQL / jackson-datatype-jsr310 are BOM-managed by Boot and move with a future Boot bump, not individually.
- assertj-core and jakarta.validation-api only offer 4.0.0-M1 milestones — deliberately held.

## Verification
Re-ran `./gradlew dependencyUpdates -Drevision=release`: build successful, deprecation warning gone, plugin reports 0.61.0 as latest.