### PR TITLE
docs: fix UserPreDeleteEvent accessors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ To facilitate this in a decoupled manner, the framework publishes a UserPreDelet
 
 Consuming applications that have extended BaseUserProfile (or have other user-related data) should listen for this event and perform the necessary cleanup operations.
 
-Event Class: com.digitalsanctuary.spring.user.event.UserPreDeleteEvent Event Data: Contains the User entity that is about to be deleted (event.getUser()).
+Event Class: com.digitalsanctuary.spring.user.event.UserPreDeleteEvent Event Data: the id and email of the user about to be deleted (`event.getUserId()`, `event.getUserEmail()`). The `User` entity itself is not carried on the event.
 
 Example Event Listener:
 
@@ -995,7 +995,7 @@ public class UserProfileDeletionListener {
     @EventListener
     @Transactional // Joins the transaction started by UserService.deleteUserAccount
     public void handleUserPreDelete(UserPreDeleteEvent event) {
-        Long userId = event.getUser().getId();
+        Long userId = event.getUserId();
         log.info("Received UserPreDeleteEvent for userId: {}. Deleting associated DemoUserProfile...", userId);
 
         // Option 1: Delete profile directly (if no further cascades needed from profile)


### PR DESCRIPTION
The README described `UserPreDeleteEvent` as carrying the `User` entity via `event.getUser()` (line 968) and used `event.getUser().getId()` in the listener example (line 998). Since 5.0.0 the event exposes only `getUserId()` and `getUserEmail()` (`UserPreDeleteEvent.java:52,61`); the example did not compile as written. Updated the description and the example to match the class and the demo app's actual `UserProfileDeletionListener`. Found while rewriting the demo app's docs (devondragon/SpringUserFrameworkDemoApp#85).