### PR TITLE
fix: bind email-only DTO on resendRegistrationToken (#361)

### DIFF
--- a/src/main/java/com/digitalsanctuary/spring/user/api/UserAPI.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/api/UserAPI.java
@@ -22,6 +22,7 @@ import com.digitalsanctuary.spring.user.dto.AuthMethodsResponse;
 import com.digitalsanctuary.spring.user.dto.PasswordDto;
 import com.digitalsanctuary.spring.user.dto.PasswordResetRequestDto;
 import com.digitalsanctuary.spring.user.dto.PasswordlessRegistrationDto;
+import com.digitalsanctuary.spring.user.dto.ResendVerificationDto;
 import com.digitalsanctuary.spring.user.dto.SavePasswordDto;
 import com.digitalsanctuary.spring.user.dto.SetPasswordDto;
 import com.digitalsanctuary.spring.user.dto.UserDto;
@@ -183,19 +184,19 @@ public class UserAPI {
 	 * Resends the registration token. This is used when the user did not receive
 	 * the initial registration email.
 	 *
-	 * @param userDto the user data transfer object containing user details
+	 * @param resendVerificationDto the DTO containing the email address to resend the verification email to
 	 * @param request the HTTP servlet request
 	 * @return a ResponseEntity containing a JSONResponse with the registration
 	 *         result
 	 */
 	@PostMapping("/resendRegistrationToken")
-	public ResponseEntity<JSONResponse> resendRegistrationToken(@Valid @RequestBody UserDto userDto,
+	public ResponseEntity<JSONResponse> resendRegistrationToken(@Valid @RequestBody ResendVerificationDto resendVerificationDto,
 			HttpServletRequest request) {
 		// Anti-enumeration: this endpoint ALWAYS returns the same generic 200 response, regardless of
 		// whether the email is unknown, already verified, or genuinely awaiting verification. Internally
 		// we only send the verification email when the account exists AND is still unverified. The true
 		// outcome is recorded server-side via audit/log events so operators retain visibility.
-		User user = userService.findUserByEmail(userDto.getEmail());
+		User user = userService.findUserByEmail(resendVerificationDto.getEmail());
 		if (user == null) {
 			log.info("Resend verification requested for unknown email; returning generic response.");
 			logAuditEvent("Resend Reg Token", "Failure", "Unknown Email", null, request);

--- a/src/main/java/com/digitalsanctuary/spring/user/api/UserAPI.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/api/UserAPI.java
@@ -186,8 +186,8 @@ public class UserAPI {
 	 *
 	 * @param resendVerificationDto the DTO containing the email address to resend the verification email to
 	 * @param request the HTTP servlet request
-	 * @return a ResponseEntity containing a JSONResponse with the registration
-	 *         result
+	 * @return a ResponseEntity containing a generic JSONResponse that is identical whether or not a
+	 *         verification email was actually resent
 	 */
 	@PostMapping("/resendRegistrationToken")
 	public ResponseEntity<JSONResponse> resendRegistrationToken(@Valid @RequestBody ResendVerificationDto resendVerificationDto,

--- a/src/main/java/com/digitalsanctuary/spring/user/dto/ResendVerificationDto.java
+++ b/src/main/java/com/digitalsanctuary/spring/user/dto/ResendVerificationDto.java
@@ -1,0 +1,26 @@
+package com.digitalsanctuary.spring.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Data Transfer Object for resending a registration verification email.
+ * <p>
+ * Contains only the email address needed to resend the verification email. Binding this instead of
+ * the registration {@link UserDto} keeps the endpoint from requiring name and password fields a
+ * resend request has no reason to carry.
+ * </p>
+ *
+ * @author Devon Hillard
+ */
+@Data
+public class ResendVerificationDto {
+
+    /** The email address to resend the verification email to. */
+    @NotBlank(message = "Email is required")
+    @Email(message = "Please provide a valid email address")
+    @Size(max = 100, message = "Email must not exceed 100 characters")
+    private String email;
+}

--- a/src/test/java/com/digitalsanctuary/spring/user/api/UserAPIUnitTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/UserAPIUnitTest.java
@@ -22,6 +22,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Map;
 
 import com.digitalsanctuary.spring.user.audit.AuditEvent;
 import com.digitalsanctuary.spring.user.dto.PasswordDto;
@@ -409,7 +410,7 @@ public class UserAPIUnitTest {
             // When & Then - no 400 from registration-only validation constraints
             mockMvc.perform(post("/user/resendRegistrationToken")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("{\"email\":\"" + testUserDto.getEmail() + "\"}")
+                    .content(objectMapper.writeValueAsString(Map.of("email", testUserDto.getEmail())))
                     .with(csrf()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true));

--- a/src/test/java/com/digitalsanctuary/spring/user/api/UserAPIUnitTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/UserAPIUnitTest.java
@@ -26,6 +26,7 @@ import java.util.Locale;
 import com.digitalsanctuary.spring.user.audit.AuditEvent;
 import com.digitalsanctuary.spring.user.dto.PasswordDto;
 import com.digitalsanctuary.spring.user.dto.SetPasswordDto;
+import com.digitalsanctuary.spring.user.dto.ResendVerificationDto;
 import com.digitalsanctuary.spring.user.dto.UserDto;
 import com.digitalsanctuary.spring.user.dto.UserProfileUpdateDto;
 import com.digitalsanctuary.spring.user.security.StepUpService;
@@ -343,7 +344,7 @@ public class UserAPIUnitTest {
             // When & Then
             mockMvc.perform(post("/user/resendRegistrationToken")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(testUserDto))
+                    .content(resendJson(testUserDto.getEmail()))
                     .with(csrf()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -363,7 +364,7 @@ public class UserAPIUnitTest {
             // When & Then - same response as the unverified case, and no email is sent
             mockMvc.perform(post("/user/resendRegistrationToken")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(testUserDto))
+                    .content(resendJson(testUserDto.getEmail()))
                     .with(csrf()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -383,7 +384,7 @@ public class UserAPIUnitTest {
             // When & Then - same uniform 200 response; nothing leaks existence
             mockMvc.perform(post("/user/resendRegistrationToken")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(testUserDto))
+                    .content(resendJson(testUserDto.getEmail()))
                     .with(csrf()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -392,6 +393,80 @@ public class UserAPIUnitTest {
                             .value("If your account requires verification, a new verification email has been sent."));
 
             verify(userEmailService, never()).sendRegistrationVerificationEmail(any(User.class), anyString());
+        }
+
+        @Test
+        @DisplayName("POST /user/resendRegistrationToken - email-only body with no name or password is accepted")
+        void resendRegistrationToken_emailOnlyBody_isAccepted() throws Exception {
+            // Given - the body the resend page actually posts: just an email, no name or password fields
+            User unverifiedUser = UserTestDataBuilder.aUser()
+                    .withEmail(testUserDto.getEmail())
+                    .disabled()
+                    .build();
+            when(userService.findUserByEmail(testUserDto.getEmail())).thenReturn(unverifiedUser);
+            when(appUrlResolver.resolveAppUrl(any())).thenReturn("http://localhost:8080");
+
+            // When & Then - no 400 from registration-only validation constraints
+            mockMvc.perform(post("/user/resendRegistrationToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"email\":\"" + testUserDto.getEmail() + "\"}")
+                    .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            verify(userEmailService).sendRegistrationVerificationEmail(eq(unverifiedUser), anyString());
+        }
+
+        @Test
+        @DisplayName("POST /user/resendRegistrationToken - blank email is rejected with 400 and sends no email")
+        void resendRegistrationToken_blankEmail_returnsBadRequest() throws Exception {
+            mockMvc.perform(post("/user/resendRegistrationToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(resendJson(""))
+                    .with(csrf()))
+                    .andExpect(status().isBadRequest());
+
+            verify(userEmailService, never()).sendRegistrationVerificationEmail(any(User.class), anyString());
+        }
+
+        @Test
+        @DisplayName("POST /user/resendRegistrationToken - malformed email is rejected with 400 and sends no email")
+        void resendRegistrationToken_malformedEmail_returnsBadRequest() throws Exception {
+            mockMvc.perform(post("/user/resendRegistrationToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(resendJson("not-an-email"))
+                    .with(csrf()))
+                    .andExpect(status().isBadRequest());
+
+            verify(userEmailService, never()).sendRegistrationVerificationEmail(any(User.class), anyString());
+        }
+
+        @Test
+        @DisplayName("POST /user/resendRegistrationToken - a legacy full registration payload is still accepted")
+        void resendRegistrationToken_legacyFullUserDtoPayload_isAccepted() throws Exception {
+            // Given - clients built against the old signature still post the whole registration UserDto
+            User unverifiedUser = UserTestDataBuilder.aUser()
+                    .withEmail(testUserDto.getEmail())
+                    .disabled()
+                    .build();
+            when(userService.findUserByEmail(testUserDto.getEmail())).thenReturn(unverifiedUser);
+            when(appUrlResolver.resolveAppUrl(any())).thenReturn("http://localhost:8080");
+
+            // When & Then - the extra fields are ignored rather than rejected
+            mockMvc.perform(post("/user/resendRegistrationToken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(testUserDto))
+                    .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            verify(userEmailService).sendRegistrationVerificationEmail(eq(unverifiedUser), anyString());
+        }
+
+        private String resendJson(String email) throws Exception {
+            ResendVerificationDto dto = new ResendVerificationDto();
+            dto.setEmail(email);
+            return objectMapper.writeValueAsString(dto);
         }
     }
 

--- a/src/test/java/com/digitalsanctuary/spring/user/api/UserAPIUnitTest.java
+++ b/src/test/java/com/digitalsanctuary/spring/user/api/UserAPIUnitTest.java
@@ -25,8 +25,8 @@ import java.util.Locale;
 
 import com.digitalsanctuary.spring.user.audit.AuditEvent;
 import com.digitalsanctuary.spring.user.dto.PasswordDto;
-import com.digitalsanctuary.spring.user.dto.SetPasswordDto;
 import com.digitalsanctuary.spring.user.dto.ResendVerificationDto;
+import com.digitalsanctuary.spring.user.dto.SetPasswordDto;
 import com.digitalsanctuary.spring.user.dto.UserDto;
 import com.digitalsanctuary.spring.user.dto.UserProfileUpdateDto;
 import com.digitalsanctuary.spring.user.security.StepUpService;


### PR DESCRIPTION
## Problem

`POST /user/resendRegistrationToken` could never succeed. It bound the registration `UserDto`, which carries `@NotBlank` on `firstName`, `lastName`, `password`, and `matchingPassword`. A resend request only has an email address, so validation always failed with HTTP 400 and no mail was sent.

Reported in #361, found while verifying the demo app against a real mail catcher (devondragon/SpringUserFrameworkDemoApp#87).

## Fix

- New `ResendVerificationDto` with a single `@NotBlank @Email @Size(max = 100) String email`, mirroring the existing `PasswordResetRequestDto`.
- `UserAPI.resendRegistrationToken` binds it instead of `UserDto`. The handler body already used only `getEmail()`, so the anti-enumeration generic response and audit events are unchanged.
- `POST /user/resetPassword` was checked for the same problem as the issue suggested: it already binds `PasswordResetRequestDto`, so no change was needed. `registerUserAccount` is now the only endpoint binding `UserDto`, and it legitimately needs every field.

Not a breaking change for consumers: clients still posting the full registration payload keep working, since the extra properties are ignored rather than rejected. That is covered by a test rather than assumed.

## Tests

`UserAPIUnitTest` resend coverage, all passing:

- email-only body `{"email": "..."}` is accepted and sends the email (the case that used to 400)
- legacy full registration payload still accepted
- blank email and malformed email each return 400 and send no email
- the three existing uniform-response tests (unverified / already verified / unknown email) still pass, now posting an email-only body

`./gradlew build` (test + check) passes.

Closes #361