### PR TITLE
docs: align README install versions with 5.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ Spring Boot 4.x brings significant changes including Spring Security 7 and requi
 <dependency>
     <groupId>com.digitalsanctuary</groupId>
     <artifactId>ds-spring-user-framework</artifactId>
-    <version>5.3.0</version>
+    <version>5.3.1</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.0'
+implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.1'
 ```
 
 #### Spring Boot 4.x Key Changes
@@ -214,7 +214,7 @@ Follow these steps to get up and running with the Spring User Framework in your 
 
    **Spring Boot 4.0 / 4.1 (Java 21+):**
    ```groovy
-   implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.0'
+   implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.1'
    ```
 
    **Spring Boot 3.5 (Java 17+):**


### PR DESCRIPTION
Bumps the README Maven/Gradle install snippets from 5.3.0 to 5.3.1 following the 5.3.1 release. The compatibility matrix already reads 5.3.x and the CHANGELOG 5.3.1 section is correct, so no other changes were needed.

Docs only, no runtime changes.