### PR TITLE
docs: align README install versions with 5.3.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ Spring Boot 4.x brings significant changes including Spring Security 7 and requi
 <dependency>
     <groupId>com.digitalsanctuary</groupId>
     <artifactId>ds-spring-user-framework</artifactId>
-    <version>5.3.2</version>
+    <version>5.3.3</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.2'
+implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.3'
 ```
 
 #### Spring Boot 4.x Key Changes
@@ -214,7 +214,7 @@ Follow these steps to get up and running with the Spring User Framework in your 
 
    **Spring Boot 4.0 / 4.1 (Java 21+):**
    ```groovy
-   implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.2'
+   implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.3'
    ```
 
    **Spring Boot 3.5 (Java 17+):**


### PR DESCRIPTION
## Summary
- Updates Maven and Gradle install snippets in README.md from 5.3.2 to 5.3.3 (three occurrences: Installation section, Quick Start Step 1 for Boot 4.x and Boot 3.5 comparison)

## Test plan
- [ ] Verify version strings in rendered README

https://claude.ai/code/session_01SNYPJ14JEtvyE1LW1MV1t6