### PR TITLE
docs: align README install versions with 5.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ SemVer classification: patch — security hardening and behavioral fixes with no
   - Passkey delete/rename/remove‑password endpoints consult it only when user.security.stepUp.enabled=true (no surprise enforcement for 5.3.1 SPI adopters).
 - CONFIG.md: documents that step‑up re‑assertion preserves the session id while rotating the CSRF token, and that clients must refresh the CSRF token before retrying a gated operation.
 - MIGRATION.md: adds a 5.3.3 → 5.3.4 callout noting the enrollment denial change from HTTP 403 to HTTP 401 + {"error":"step-up-required"} and directing clients that branched on 403 to also handle the new 401 contract.
-- README.md: aligns install snippets to 5.3.3.
+- README.md: aligns install snippets to 5.3.4.
 
 ### Testing
 - Adds mock‑based unit tests covering passwordless registration retries (retry‑then‑succeed, DataIntegrityViolationException→409, exhausted‑retries propagate, unrelated exception not swallowed).

--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ Spring Boot 4.x brings significant changes including Spring Security 7 and requi
 <dependency>
     <groupId>com.digitalsanctuary</groupId>
     <artifactId>ds-spring-user-framework</artifactId>
-    <version>5.3.3</version>
+    <version>5.3.4</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.3'
+implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.4'
 ```
 
 #### Spring Boot 4.x Key Changes
@@ -214,7 +214,7 @@ Follow these steps to get up and running with the Spring User Framework in your 
 
    **Spring Boot 4.0 / 4.1 (Java 21+):**
    ```groovy
-   implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.3'
+   implementation 'com.digitalsanctuary:ds-spring-user-framework:5.3.4'
    ```
 
    **Spring Boot 3.5 (Java 17+):**


### PR DESCRIPTION
Bumps the three Spring Boot 4.x install snippets (Maven `<version>` and the two Gradle lines) from 5.3.3 to 5.3.4 following the 5.3.4 release. The Spring Boot 3.5 / Java 17 security-maintenance line stays at 3.6.0.

Also corrects the 5.3.4 CHANGELOG entry, which said the README aligned to "5.3.3" — it aligns to 5.3.4.

Docs-only.

https://claude.ai/code/session_01KL5qvKVGQLLQDjHToy34vj